### PR TITLE
Fix arguments

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -8,14 +8,13 @@ let uuid = require('node-uuid');
 var os = require('os');
 
 function uploadCwdToSource(app, cwd) {
-  let tempFilePath = os.tmpdir() + uuid.v4() + '.tar.gz';
+  let tempFilePath = `${os.tmpdir()}${uuid.v4()}.tar.gz`;
 
   return app.sources().create({}).then(function(source){
     let archive = archiver('tar', { gzip: true });
     archive.on('finish', function (err) {
-      if (err) {
-        throw err;
-      }
+      if (err) { throw err; }
+
       let filesize = fs.statSync(tempFilePath).size;
       let request_options = {
         url: source.source_blob.put_url,
@@ -54,7 +53,7 @@ function create(context) {
   sourceUrlPromise.then(function(sourceGetUrl) {
     // TODO we have to bail out to `request` to get edge version
     heroku.request({
-      path: '/apps/' + context.app + '/builds',
+      path: `/apps/${context.app}/builds`,
       method: 'POST',
       headers: {
         'Accept': 'application/vnd.heroku+json; version=edge'
@@ -64,7 +63,7 @@ function create(context) {
         source_blob: {
           url: sourceGetUrl,
           // TODO provide better default, eg. archive md5
-          version: context.args['version'] || ''
+          version: context.args.version || ''
         }
       }
     }).then(function(build) {
@@ -80,10 +79,9 @@ module.exports = {
   needsApp: true,
   help: 'Create build from contents of current dir',
   description: 'create build',
-  flags: [],
-  args: [
-    { name: 'source-url', optional: true },
-    { name: 'version', optional: true }
+  flags: [
+    { name: 'source-url', description: 'Source URL that points to the tarball of your application\'s source code', hasValue: true},
+    { name: 'version', description: 'Description of your new build', hasValue: true }
   ],
   run: create
 };

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -8,85 +8,82 @@ let uuid = require('node-uuid');
 var os = require('os');
 
 function uploadCwdToSource(app, cwd) {
-    let tempFilePath = os.tmpdir() + uuid.v4() + '.tar.gz';
+  let tempFilePath = os.tmpdir() + uuid.v4() + '.tar.gz';
 
-    return app.sources().create({})
-	.then(function(source){
-	    let archive = archiver('tar', { gzip: true });
-	    archive.on('finish', function (err) {
-		if (err) {
-		    throw err;
-		}
-		let filesize = fs.statSync(tempFilePath).size;
-		let request_options = {
-		    url: source.source_blob.put_url,
-		    headers: {
-			'Content-Type': '',
-			'Content-Length': filesize
-		    }
-		};
+  return app.sources().create({}).then(function(source){
+    let archive = archiver('tar', { gzip: true });
+    archive.on('finish', function (err) {
+      if (err) {
+        throw err;
+      }
+      let filesize = fs.statSync(tempFilePath).size;
+      let request_options = {
+        url: source.source_blob.put_url,
+        headers: {
+         'Content-Type': '',
+         'Content-Length': filesize
+        }
+      };
 
-		var stream = fs.createReadStream(tempFilePath);
-		stream.on('close', function() {
-		    fs.unlink(tempFilePath);
-		});
+      var stream = fs.createReadStream(tempFilePath);
+      stream.on('close', function() {
+        fs.unlink(tempFilePath);
+      });
 
-		stream .pipe(request.put(request_options));
-	    });
-	    let output = fs.createWriteStream(tempFilePath);
-	    archive.pipe(output);
-	    // TODO: Don't add things that we don't want
-	    // eg. `.git` and things in `.gitignore`
-	    archive.directory(cwd, false).finalize();
+      stream .pipe(request.put(request_options));
+    });
 
-	    return source.source_blob.get_url;
-	});
+    let output = fs.createWriteStream(tempFilePath);
+    archive.pipe(output);
+    // TODO: Don't add things that we don't want
+    // eg. `.git` and things in `.gitignore`
+    archive.directory(cwd, false).finalize();
+
+    return source.source_blob.get_url;
+  });
 }
 
 function create(context) {
-    let heroku = new Heroku({ token: context.auth.password });
-    let app = heroku.apps(context.app);
+  let heroku = new Heroku({ token: context.auth.password });
+  let app = heroku.apps(context.app);
 
-    var sourceUrl = context.args['source-url'];
+  var sourceUrl = context.args['source-url'];
 
-    var sourceUrlPromise = sourceUrl ?
-	new Promise(function(resolve) { resolve(sourceUrl);}) :
-	uploadCwdToSource(app, context.cwd);
+  var sourceUrlPromise = sourceUrl ? new Promise(function(resolve) { resolve(sourceUrl);}) : uploadCwdToSource(app, context.cwd);
 
-    sourceUrlPromise
-	.then(function(sourceGetUrl) {
-	    // TODO we have to bail out to `request` to get edge version
-	    heroku.request({
-		path: '/apps/' + context.app + '/builds',
-		method: 'POST',
-		headers: {
-		    'Accept': 'application/vnd.heroku+json; version=edge'
-		},
-		parseJSON: true,
-		body: {
-		    source_blob: {
-			url: sourceGetUrl,
-			// TODO provide better default, eg. archive md5
-			version: context.args['version'] || ''
-		    }
-		}
-	    }).then(function(build) {
-		request.get(build.stream_url).pipe(process.stderr);
-	    }).done();
-	});
+  sourceUrlPromise.then(function(sourceGetUrl) {
+    // TODO we have to bail out to `request` to get edge version
+    heroku.request({
+      path: '/apps/' + context.app + '/builds',
+      method: 'POST',
+      headers: {
+        'Accept': 'application/vnd.heroku+json; version=edge'
+      },
+      parseJSON: true,
+      body: {
+        source_blob: {
+          url: sourceGetUrl,
+          // TODO provide better default, eg. archive md5
+          version: context.args['version'] || ''
+        }
+      }
+    }).then(function(build) {
+      request.get(build.stream_url).pipe(process.stderr);
+    }).done();
+  });
 }
 
 module.exports = {
-    topic: 'builds',
-    command: 'create',
-    needsAuth: true,
-    needsApp: true,
-    help: 'Create build from contents of current dir',
-    description: 'create build',
-    flags: [],
-    args: [
-	{ name: 'source-url', optional: true },
-	{ name: 'version', optional: true }
-    ],
-    run: create
+  topic: 'builds',
+  command: 'create',
+  needsAuth: true,
+  needsApp: true,
+  help: 'Create build from contents of current dir',
+  description: 'create build',
+  flags: [],
+  args: [
+    { name: 'source-url', optional: true },
+    { name: 'version', optional: true }
+  ],
+  run: create
 };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -4,38 +4,38 @@ let Heroku = require('heroku-client');
 let columnify = require('columnify');
 
 module.exports = {
-    topic: 'builds',
-    needsAuth: true,
-    needsApp: true,
-    description: 'list builds',
-    help: 'List builds for a Heroku app',
-    args: [],
-    flags: [],
-    run: function (context) {
-	let heroku = new Heroku({ token: context.auth.password });
+  topic: 'builds',
+  needsAuth: true,
+  needsApp: true,
+  description: 'list builds',
+  help: 'List builds for a Heroku app',
+  args: [],
+  flags: [],
+  run: function (context) {
+    let heroku = new Heroku({ token: context.auth.password });
 
-	heroku.request({
-	    path: '/apps/' + context.app + '/builds',
-	    method: 'GET',
-	    headers: {
-		'Range': 'created_at ..; order=desc;'
-	    },
-	    parseJSON: true
-	}).then(function (builds) {
-	    var columnData = builds.slice(0, 10).map(function(build) {
-		return { created_at: build.created_at,
-			 status: build.status,
-			 version: build.source_blob.version,
-			 user: build.user.email
-		       };
-	    });
-	    // TODO: use `max` directive in query to avoid the slice nonsense
-	    // heroku-client currently breaks if one tries to do this
-	    var columns = columnify(columnData, {
-		showHeaders: false
-	    });
-	    
-	    console.log(columns);
-	});	
-    }
+    heroku.request({
+       path: '/apps/' + context.app + '/builds',
+       method: 'GET',
+       headers: {
+        'Range': 'created_at ..; order=desc;'
+      },
+      parseJSON: true
+    }).then(function (builds) {
+      var columnData = builds.slice(0, 10).map(function(build) {
+        return { created_at: build.created_at,
+          status: build.status,
+          version: build.source_blob.version,
+          user: build.user.email
+        };
+      });
+
+      // TODO: use `max` directive in query to avoid the slice nonsense
+      // heroku-client currently breaks if one tries to do this
+      var columns = columnify(columnData, {
+        showHeaders: false
+      });
+      console.log(columns);
+    });
+  }
 };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -9,13 +9,11 @@ module.exports = {
   needsApp: true,
   description: 'list builds',
   help: 'List builds for a Heroku app',
-  args: [],
-  flags: [],
   run: function (context) {
     let heroku = new Heroku({ token: context.auth.password });
 
     heroku.request({
-       path: '/apps/' + context.app + '/builds',
+       path: `/apps/${context.app}/builds`,
        method: 'GET',
        headers: {
         'Range': 'created_at ..; order=desc;'


### PR DESCRIPTION
:bee: :bee: NOT TESTED

With the use of `args` instead of `flags`, the order in which those are passed in actually matter.

i.e.: `$ heroku builds --source-url URL --version VERSION` is not the same as ` `$ heroku builds --version VERSION --source-url URL`.

And for that, we take the risk of matching `context.args.version` to the wrong real flag (depending on the order of how version was passed in). Defining those in flags fixes the problem.

This PR also ~~changes~~ fixes the indentation, @friism, what editor are you using? It also makes some changes to take the advantage of string interpolation in ES6.