### PR TITLE
Initial stab at fixing race condition

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -8,11 +8,12 @@ let os = require('os');
 let path = require('path');
 let request = require('request');
 
-function uploadCwdToSource(app, cwd) {
+function uploadCwdToSource(app, cwd, fn) {
   let tempFilePath = path.join(os.tmpdir(), uuid.v4() + '.tar.gz');
 
-  return app.sources().create({}).then(function(source){
+  app.sources().create({}).then(function(source){
     let archive = archiver('tar', { gzip: true });
+
     archive.on('finish', function (err) {
       if (err) { throw err; }
 
@@ -30,7 +31,9 @@ function uploadCwdToSource(app, cwd) {
         fs.unlink(tempFilePath);
       });
 
-      stream .pipe(request.put(request_options));
+      stream.pipe(request.put(request_options, function() {
+        fn(source.source_blob.get_url);
+      }));
     });
 
     let output = fs.createWriteStream(tempFilePath);
@@ -42,8 +45,6 @@ function uploadCwdToSource(app, cwd) {
       options = { mode: 0o0755 };
     }
     archive.directory(cwd, false, options).finalize();
-
-    return source.source_blob.get_url;
   });
 }
 
@@ -53,7 +54,9 @@ function create(context) {
 
   var sourceUrl = context.args['source-url'];
 
-  var sourceUrlPromise = sourceUrl ? new Promise(function(resolve) { resolve(sourceUrl);}) : uploadCwdToSource(app, context.cwd);
+  var sourceUrlPromise = sourceUrl ?
+      new Promise(function(resolve) { resolve(sourceUrl);}) :
+      new Promise(function(resolve) { uploadCwdToSource(app, context.cwd, resolve); });
 
   sourceUrlPromise.then(function(sourceGetUrl) {
     // TODO we have to bail out to `request` to get edge version


### PR DESCRIPTION
I was seeing this race condition happen a lot, and essentially
what's happening is this:

    ------> tar -> upload
    ------> tell build API that URL is ready
    !! URL isn't ready sometimes since we did the 2 ops concurrently

The change was to only tell build API about the URL when the
upload is done.

I'm not entirely happy about the use of a callback in
`uploadCwdToSource` but trying to fit in the promise to that
function signature was even more trouble than its worth.